### PR TITLE
ICU-21508 Rename 'master' to 'main' in HOWTO-Update.md document

### DIFF
--- a/HOWTO-Update.md
+++ b/HOWTO-Update.md
@@ -2,13 +2,13 @@
 
 1. clone https://github.com/unicode-org/icu-docs
 2. in your own fork of `icu-docs`, turn on GitHub Pages
-hosting with the **Source:** set to **master branch**.
+hosting with the **Source:** set to **main branch**.
 For example, go to the settings page at https://github.com/srl295/icu-docs/settings (use your own username)
 3. You will see a note:
 > ✓ Your site is published at  https://srl295.github.io/icu-docs/
-4. You can use the above URL to view the *master* branch of your fork.
-5. Make any changes you want to make to the *master* branch _of your own fork_ . **Important**: be sure not to push to the master branch of the head fork unicode/icu-docs !
-6. To propose a change, open a PR from your fork’s master onto the head fork’s master.
+4. You can use the above URL to view the *main* branch of your fork.
+5. Make any changes you want to make to the *main* branch _of your own fork_ . **Important**: be sure not to push to the main branch of the head fork unicode/icu-docs !
+6. To propose a change, open a PR from your fork’s main onto the head fork’s main.
 
 ### License
 


### PR DESCRIPTION
The icu-docs counterpart of https://github.com/unicode-org/icu/pull/1664