### PR TITLE
ICU-21776 Update API docs update instructions

### DIFF
--- a/HOWTO-Update.md
+++ b/HOWTO-Update.md
@@ -1,14 +1,19 @@
 # How to Update `icu-docs`
 
-1. clone https://github.com/unicode-org/icu-docs
-2. in your own fork of `icu-docs`, turn on GitHub Pages
-hosting with the **Source:** set to **main branch**.
+1. Create a personal fork of <https://github.com/unicode-org/icu-docs>
+1. Clone the repository from your personal fork to create a local copy on your system
+1. In your local working copy, create a feature branch (`<FEATURE-BRANCH>`)
+1. Following the beginning of the [typical git workflow](https://icu.unicode.org/repository/gitdev):
+    a. Make any changes you want, then make a commit
+    b. Push your feature branch to your personal fork on Github
+1. On Github, in your own personal fork of `icu-docs`, turn on GitHub Pages
+hosting with the **Source:** set to your new **`<FEATURE-BRANCH>` branch**.
 For example, go to the settings page at https://github.com/srl295/icu-docs/settings (use your own username)
-3. You will see a note:
-> ✓ Your site is published at  https://srl295.github.io/icu-docs/
-4. You can use the above URL to view the *main* branch of your fork.
-5. Make any changes you want to make to the *main* branch _of your own fork_ . **Important**: be sure not to push to the main branch of the head fork unicode/icu-docs !
-6. To propose a change, open a PR from your fork’s main onto the head fork’s main.
+1. You will see a note:
+> ✓ Your site is published at <https://srl295.github.io/icu-docs/>
+1. You can use the above URL to view the changes you have made on your feature branch in your fork.
+    a. You may need to wait ~ 5 minutes ([up to 20 mins](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-jekyll-build-errors-for-github-pages-sites)) to see the changes that you pushed to your fork be re-rendered and visible on your site.
+1. After verifying that the rendered changes on your personal site look good, open a PR from your feature branch on your fork with a destination of the upstream (`unicode-org/icu-docs`) repository's `main` branch.
 
 ### License
 


### PR DESCRIPTION
In conjunction with https://github.com/unicode-org/icu/pull/1918, I want to update the instructions to avoid making changes directly on `main`, and instead to encourage the typical & repeatable Github git workflow of feature branch -> personal fork -> PR -> approval -> merge to upstream main.